### PR TITLE
Add a websocket branch middleware

### DIFF
--- a/src/Mux.jl
+++ b/src/Mux.jl
@@ -21,6 +21,6 @@ include("basics.jl")
 include("routing.jl")
 include("implementations.jl")
 
-defaults = stack(todict, basiccatch, splitquery, toresponse)
+defaults = stack(basiccatch, splitquery, toresponse)
 
 end

--- a/src/basics.jl
+++ b/src/basics.jl
@@ -26,6 +26,16 @@ function splitquery(app, req)
   app(req)
 end
 
+
+function withwebsocket(sock)
+  # giving this function a name because the error
+  # messages get better.
+  function websocket_middleware(app, req)
+    req[:websock] = sock
+    app(req)
+  end
+end
+
 params!(req) = get!(req, :params, @d())
 
 # Response

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -1,6 +1,6 @@
 using HttpCommon
 
-export method, GET, route, page, probabilty
+export method, GET, websocket, route, page, probabilty
 
 # Request type
 
@@ -35,6 +35,8 @@ function matchpath!(target, req)
   splice!(req[:path], 1:length(target))
   return true
 end
+
+websocket(app) = branch(req->haskey(req, :websocket), app)
 
 route(p, app) = branch(req -> matchpath!(p, req), app)
 route(p::String, app) = route(splitpath(p), app)


### PR DESCRIPTION
This  doesn't quite work yet...

I added `todict` as a "default default" middleware, every request the user can see is a dict now! I think this is better in an API point of view. Plus it makes storing a websocket in the request object possible.

It is meant to be used like this:

```jl
@app wsapp = (route("/echo", req -> while true
                                req[:websocket] |> ws -> write(ws, read(ws))
                         end, ...)
@app normalapp = (...)

@app both = (
    websocket(wsapp), normalapp)
```
