### PR TITLE
Explicitly import mimetypes from HttpServer as it is no longer export…

### DIFF
--- a/src/examples/files.jl
+++ b/src/examples/files.jl
@@ -1,5 +1,6 @@
 using Hiccup
 import Hiccup.div
+import HttpServer.mimetypes
 
 export files
 


### PR DESCRIPTION
…ed from HttpServer

See https://github.com/JuliaWeb/HttpServer.jl/pull/65. Without the explicit import, Mux gives a `500` error due to `mimetypes` not being defined.