### PR TITLE
Fix deprecation warnings on 0.4

### DIFF
--- a/src/basics.jl
+++ b/src/basics.jl
@@ -42,7 +42,7 @@ Response(d::Associative) =
 Response(o) = Response(stringmime(MIME"text/html"(), o))
 
 response(d) = d
-response(s::String) = @d(:body=>s)
+response(s::AbstractString) = @d(:body=>s)
 
 toresponse(app, req) = Response(response(app(req)))
 

--- a/src/examples/files.jl
+++ b/src/examples/files.jl
@@ -1,3 +1,5 @@
+using Compat
+
 using Hiccup
 import Hiccup.div
 import HttpServer.mimetypes
@@ -13,7 +15,7 @@ function validpath(root, path; dirs = true)
 end
 
 ormatch(r::RegexMatch, x) = r.match
-ormatch(r::Nothing, x) = x
+ormatch(r::(@compat Void), x) = x
 
 extension(f) = ormatch(match(r"(?<=\.)[^\.\\/]*$", f), "")
 

--- a/src/routing.jl
+++ b/src/routing.jl
@@ -4,14 +4,14 @@ export method, GET, route, page, probabilty
 
 # Request type
 
-method(m::String, app...) = branch(req -> req[:method] == m, app...)
+method(m::AbstractString, app...) = branch(req -> req[:method] == m, app...)
 method(ms, app...) = branch(req -> req[:method] in ms, app...)
 
 GET(app...) = method("GET", app...)
 
 # Path routing
 
-splitpath(p::String) = @compat split(p, "/", keep=false)
+splitpath(p::AbstractString) = @compat split(p, "/", keep=false)
 splitpath(p) = p
 
 function matchpath(target, path)
@@ -36,11 +36,11 @@ function matchpath!(target, req)
 end
 
 route(p, app...) = branch(req -> matchpath!(p, req), app...)
-route(p::String, app...) = route(splitpath(p), app...)
+route(p::AbstractString, app...) = route(splitpath(p), app...)
 route(app::Function, p) = route(p, app)
 
 page(p::Vector, app...) = branch(req -> length(p) == length(req[:path]) && matchpath!(p, req), app...)
-page(p::String, app...) = page(splitpath(p), app...)
+page(p::AbstractString, app...) = page(splitpath(p), app...)
 page(app...) = page([], app...)
 page(app::Function, p) = page(p, app)
 


### PR DESCRIPTION
update: changed `Void` to (`@compat Void`) to avoid @shashi's concern about v0.3